### PR TITLE
fix: cache falsy variable values

### DIFF
--- a/specs/container.spec.js
+++ b/specs/container.spec.js
@@ -40,6 +40,14 @@ describe('Container', () => {
       given('random', () => Math.random());
       expect(given.random).toBe(given.random);
     });
+
+    it('should cache falsy variable values', () => {
+      let counter = 0;
+      // eslint-disable-next-line no-plusplus
+      given('zero', () => counter++);
+      expect(given.zero).toBe(0);
+      expect(given.zero).toBe(0);
+    });
   });
 
   describe('without caching', () => {

--- a/src/container.js
+++ b/src/container.js
@@ -79,11 +79,11 @@ module.exports = function Container(run) {
   function define(options, fn) {
     const env = given.__env__;
     const { name, immediate, cache } = options;
-    env[name] = undefined;
+    delete env[name];
 
     const handler = () => {
       if (cache === false) return fn();
-      if (env[name]) return env[name];
+      if (name in env) return env[name];
       env[name] = fn();
       return env[name];
     };
@@ -150,7 +150,7 @@ module.exports = function Container(run) {
     enumerable: false,
     writable: false,
     value: () => {
-      const keys = Object.keys(given.__env__);
+      const keys = Object.keys(given);
       given.__env__ = {};
       keys.forEach(k => delete given[k]);
     },
@@ -162,7 +162,7 @@ module.exports = function Container(run) {
     writable: false,
     value: (key) => {
       if (key) {
-        given.__env__[key] = undefined;
+        delete given.__env__[key];
       } else {
         given.__env__ = {};
       }


### PR DESCRIPTION
The current version of the library doesn't cache falsy values. This pull request fixes it